### PR TITLE
The company is now Stack Overflow (with a space)

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,7 +369,7 @@ For more information, please visit <a href='http://www.elsevier.com'>www.elsevie
         <ul>
           <li>Ted Kull, SIAM</li>
           <li>Robert Harington, AMS</li>
-          <li>David Fullerton, StackExchange</li>
+          <li>David Fullerton, Stack Overflow</li>
           <li>Ken Rawson, IEEE</li>
           <li>Paul Mostert, Elsevier</li>
           <li>Tim Butz, Cengage</li>


### PR DESCRIPTION
See http://blog.stackoverflow.com/2015/09/were-changing-our-name-back-to-stack-overflow/
