### PR TITLE
Replace zoom code with a version that disables updates during typesetting.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,13 +33,15 @@
         CommonHTML: { linebreaks: { automatic: true } },
         "HTML-CSS": { linebreaks: { automatic: true } },
         SVG: { linebreaks: { automatic: true } },
+        TeX: { noErrors: { disabled: true } },
         MathMenu: {
-        styles: {
-          ".MathJax_Menu": {"z-index":2001}
-        }
+          styles: {
+            ".MathJax_Menu": {"z-index":2001}
+          }
         },
         AuthorInit: function () {
           MathJax.Hub.Register.StartupHook("MathMenu Ready",function () {MathJax.Menu.BGSTYLE["z-index"] = 2000;});
+          MathJax.Hub.processSectionDelay = 0;
         }
       }
     </script>


### PR DESCRIPTION
This turns off `processSectionDelay` and uses Rerender rather than Reprocess actions to avoid the heigh flickering issue.  It also prevents queuing of typesetting commands while MathJax is already in the process of typesetting.  It makes the slider more responsive, and makes the type-in respond on a return rather than on every keystroke.

I tested the code in a separate page, but don't have the setup to test it _in situ_.
