### PR TITLE
Live Demo opening up without spaces pre-filled

### DIFF
--- a/index.html
+++ b/index.html
@@ -938,8 +938,7 @@ For more information, please visit <a href='http://www.elsevier.com'>www.elsevie
         <p><a href="https://github.com/mathjax/MathJax/blob/master/test/sample-dynamic-2.html">Source on GitHub</a>
         </p>
 
-        <textarea id="MathInput" rows="10" onkeyup="Preview.Update()" style="margin-top:5px; width: 100%;">
-        </textarea>
+        <textarea id="MathInput" rows="10" onkeyup="Preview.Update()" style="margin-top:5px; width: 100%;"></textarea>
         <br/>
         <br/>Preview is shown here:
         <div id="MathPreview" style="border:1px solid; padding: 3px; width:50%; margin-top:5px"></div>


### PR DESCRIPTION
This (quick online) edit should prevent 8 spaces showing up in the textarea when clicking "Try a live demo".
