### PR TITLE
Fix the default MathJax v2 script snippet

### DIFF
--- a/_includes/frontpage/docs.html
+++ b/_includes/frontpage/docs.html
@@ -159,7 +159,7 @@
         version 2 into your page, use this snippet:
       </p>
       <div class="snippet">
-        <pre>&lt;script async src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_CHTML"&gt;&lt;/script&gt;</code></pre>
+        <pre>&lt;script async src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_CHTML"&gt;&lt;/script&gt;</code></pre>
       </div>
       <p>
       More information is available in the version 2 documentation at the link below.


### PR DESCRIPTION
The [MathJax website](https://www.mathjax.org/#gettingstarted) suggests using the following URL if you want to load MathJax v2 in a `<script>` tag:

```
https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_CHTML
```

But that looks to be broken -- in the browser, MathJax fails to load with:

```
GET https://cdn.jsdelivr.net/npm/mathjax@2/config/TeX-AMS-MML_CHTML.js?V=2.7.9 net::ERR_ABORTED 404
```

As far as I can tell, it's because [there is no such `.js` file under `config/`](https://cdn.jsdelivr.net/npm/mathjax@2/config/) for 2.7.9.

Unless it's a CDN problem, I am guessing a different `?config` should be used. Here I suggest switching it to `?config=TeX-AMS_CHTML`, which does load properly, although I do not really have an opinion on whether that's the configuration that should be recommended as the default.